### PR TITLE
remove intercepts by service ID instead of name

### DIFF
--- a/include/ziti/ziti_tunneler.h
+++ b/include/ziti/ziti_tunneler.h
@@ -35,7 +35,8 @@ typedef struct tunneler_ctx_s *tunneler_context;
 typedef struct tunneler_io_ctx_s *tunneler_io_context;
 
 /** data needed to dial a ziti service when a client connection is intercepted */
-typedef struct intercept_ctx_s{
+typedef struct intercept_ctx_s {
+    const char *  service_id;
     const char *  service_name;
     const void *  ziti_ctx;
 } intercept_ctx_t;
@@ -62,9 +63,9 @@ typedef struct tunneler_sdk_options_s {
 
 extern tunneler_context ziti_tunneler_init(tunneler_sdk_options *opts, uv_loop_t *loop);
 
-extern int ziti_tunneler_intercept_v1(tunneler_context tnlr_ctx, const void *ziti_ctx, const char *service_name, const char *hostname, int port);
+extern int ziti_tunneler_intercept_v1(tunneler_context tnlr_ctx, const void *ziti_ctx, const char *service_id, const char *service_name, const char *hostname, int port);
 
-extern void ziti_tunneler_stop_intercepting(tunneler_context tnlr_ctx, const char *service_name);
+extern void ziti_tunneler_stop_intercepting(tunneler_context tnlr_ctx, const char *service_id);
 
 extern void ziti_tunneler_dial_completed(tunneler_io_context *tnlr_io_ctx, void *ziti_io_ctx, bool ok);
 

--- a/lib/intercept.c
+++ b/lib/intercept.c
@@ -6,7 +6,7 @@
 #include "intercept.h"
 #include "ziti_tunneler_priv.h"
 
-extern int add_v1_intercept(tunneler_context tnlr_ctx, const void *ziti_ctx, const char *service_name, const char *hostname, int port) {
+extern int add_v1_intercept(tunneler_context tnlr_ctx, const void *ziti_ctx, const char *service_id, const char *service_name, const char *hostname, int port) {
     if (tnlr_ctx == NULL) {
         ZITI_LOG(ERROR, "null tnlr_ctx");
         return -1;
@@ -18,6 +18,7 @@ extern int add_v1_intercept(tunneler_context tnlr_ctx, const void *ziti_ctx, con
     }
 
     new = calloc(1, sizeof(struct intercept_s));
+    new->ctx.service_id = strdup(service_id);
     new->ctx.service_name = strdup(service_name);
     new->ctx.ziti_ctx = ziti_ctx;
     new->next = NULL;
@@ -26,6 +27,7 @@ extern int add_v1_intercept(tunneler_context tnlr_ctx, const void *ziti_ctx, con
     if (ipaddr_aton(hostname, &new->cfg.v1.resolved_hostname) == 0) {
         /* TODO generate IP address when service cfg uses hostname. */
         ZITI_LOG(ERROR, "sorry! support for DNS hostnames is coming soon");
+        free((char *)new->ctx.service_id);
         free((char *)new->ctx.service_name);
         free(new->cfg.v1.hostname);
         free(new);
@@ -42,7 +44,7 @@ extern int add_v1_intercept(tunneler_context tnlr_ctx, const void *ziti_ctx, con
     return 0;
 }
 
-void remove_intercept(tunneler_context tnlr_ctx, const char *service_name) {
+void remove_intercept(tunneler_context tnlr_ctx, const char *service_id) {
     struct intercept_s *intercept, *prev = NULL;
 
     if (tnlr_ctx == NULL) {
@@ -51,17 +53,21 @@ void remove_intercept(tunneler_context tnlr_ctx, const char *service_name) {
     }
 
     for (intercept = tnlr_ctx->intercepts; intercept != NULL; intercept = intercept->next) {
-        if (strcmp(intercept->ctx.service_name, service_name) == 0) {
+        if (strcmp(intercept->ctx.service_id, service_id) == 0) {
+            ZITI_LOG(INFO, "removing intercept for service %s (id %s)", intercept->ctx.service_name, service_id);
             if (prev != NULL) {
                 prev->next = intercept->next;
             } else {
                 tnlr_ctx->intercepts = intercept->next;
             }
-            // TODO close active connections
+            free((char *)intercept->ctx.service_id);
             free((char *)intercept->ctx.service_name);
             switch (intercept->cfg_version) {
                 case 1:
                     free(intercept->cfg.v1.hostname);
+                    break;
+                default:
+                    ZITI_LOG(DEBUG, "unknown config version %d", intercept->cfg_version);
                     break;
             }
         }

--- a/lib/intercept.h
+++ b/lib/intercept.h
@@ -24,8 +24,8 @@ struct intercept_s {
     struct intercept_s *next;
 };
 
-extern int add_v1_intercept(tunneler_context tnlr_ctx, const void *ziti_ctx, const char *service_name, const char *hostname, int port);
-extern void remove_intercept(tunneler_context tnlr_ctx, const char *serivce_name);
+extern int add_v1_intercept(tunneler_context tnlr_ctx, const void *ziti_ctx, const char *service_id, const char *service_name, const char *hostname, int port);
+extern void remove_intercept(tunneler_context tnlr_ctx, const char *serivce_id);
 
 /** return the intercept context for a packet based on its destination ip:port */
 extern intercept_ctx_t *lookup_l4_intercept(tunneler_context tnlr_ctx, ip_addr_t *dst_addr, int dst_port);

--- a/lib/ziti_tunneler.c
+++ b/lib/ziti_tunneler.c
@@ -91,22 +91,23 @@ void ziti_tunneler_dial_completed(tunneler_io_context *tnlr_io_ctx, void *ziti_i
 }
 
 /** arrange to intercept traffic defined by a v1 client tunneler config */
-int ziti_tunneler_intercept_v1(tunneler_context tnlr_ctx, const void *ziti_ctx, const char *service_name, const char *hostname, int port) {
+int ziti_tunneler_intercept_v1(tunneler_context tnlr_ctx, const void *ziti_ctx, const char *service_id, const char *service_name, const char *hostname, int port) {
     ip_addr_t intercept_ip;
 
     if (ipaddr_aton(hostname, &intercept_ip) == 0) {
-        ZITI_LOG(DEBUG, "v1 intercept hostname %s for service %s is not an ip", hostname, service_name);
+        ZITI_LOG(DEBUG, "v1 intercept hostname %s for service id %s is not an ip", hostname, service_id);
         /* TODO: handle hostnames */
         return -1;
     }
 
-    add_v1_intercept(tnlr_ctx, ziti_ctx, service_name, hostname, port);
+    add_v1_intercept(tnlr_ctx, ziti_ctx, service_id, service_name, hostname, port);
 
     return 0;
 }
 
-void ziti_tunneler_stop_intercepting(tunneler_context tnlr_ctx, const char *service_name) {
-    remove_intercept(tnlr_ctx, service_name);
+void ziti_tunneler_stop_intercepting(tunneler_context tnlr_ctx, const char *service_id) {
+    ZITI_LOG(DEBUG, "removing intercept for service id %s", service_id);
+    remove_intercept(tnlr_ctx, service_id);
 }
 
 /** called by tunneler application when data is read from a ziti connection */

--- a/lib/ziti_tunneler_cbs.c
+++ b/lib/ziti_tunneler_cbs.c
@@ -46,7 +46,7 @@ void * ziti_sdk_c_dial(const intercept_ctx_t *intercept_ctx, tunneler_io_context
         ZITI_LOG(WARN, "null intercept_ctx");
         return NULL;
     }
-    ZITI_LOG(VERBOSE, "ziti_dial(%s)", intercept_ctx->service_name);
+    ZITI_LOG(VERBOSE, "ziti_dial(name=%s,id=%s)", intercept_ctx->service_name, intercept_ctx->service_id);
 
     ziti_io_context *ziti_io_ctx = malloc(sizeof(struct ziti_io_ctx_s));
     if (ziti_io_ctx == NULL) {

--- a/programs/ziti-tunneler/ziti-tunneler.c
+++ b/programs/ziti-tunneler/ziti-tunneler.c
@@ -21,13 +21,13 @@ void on_service(ziti_context ziti_ctx, ziti_service *service, int status, void *
         int rc = ziti_service_get_config(service, "ziti-tunneler-client.v1", &intercept, parse_ziti_intercept);
         if (rc == 0) {
             printf("service_available: %s\n", service->name);
-            ziti_tunneler_intercept_v1(tnlr_ctx, ziti_ctx, service->name, intercept.hostname, intercept.port);
+            ziti_tunneler_intercept_v1(tnlr_ctx, ziti_ctx, service->id, service->name, intercept.hostname, intercept.port);
             free(intercept.hostname);
         }
         printf("ziti_service_get_config rc: %d\n", rc);
     } else if (status == ZITI_SERVICE_UNAVAILABLE) {
         printf("service unavailable: %s\n", service->name);
-        ziti_tunneler_stop_intercepting(tnlr_ctx, service->name);
+        ziti_tunneler_stop_intercepting(tnlr_ctx, service->id);
     }
 }
 


### PR DESCRIPTION
service IDs are unique across all ziti contexts, so use the ID to identify intercepts that are being removed.