### PR TITLE
Io context stability

### DIFF
--- a/include/ziti/ziti_tunneler.h
+++ b/include/ziti/ziti_tunneler.h
@@ -42,8 +42,8 @@ typedef struct intercept_ctx_s {
 } intercept_ctx_t;
 
 struct io_ctx_s {
-    tunneler_io_context  tnlr_io_ctx;
-    void *               ziti_io_ctx; // context specific to ziti SDK being used by the app.
+    tunneler_io_context * tnlr_io_ctx_p; // use pointer to allow tsdk and zsdk callbacks to see when context is nulled.
+    void *                ziti_io_ctx; // context specific to ziti SDK being used by the app.
 };
 
 /**

--- a/lib/tunneler_tcp.c
+++ b/lib/tunneler_tcp.c
@@ -185,7 +185,6 @@ void tunneler_tcp_dial_completed(tunneler_io_context *tnlr_io_ctx, void *ziti_io
     }
 
     tcp_output((*tnlr_io_ctx)->tcp);
-    memp_free(MEMP_TCP_PCB_LISTEN, pcb->listener);
 }
 
 static tunneler_io_context new_tunneler_io_context(tunneler_context tnlr_ctx, const char *service_name, struct tcp_pcb *pcb) {
@@ -272,6 +271,6 @@ u8_t recv_tcp(void *tnlr_ctx_arg, struct raw_pcb *pcb, struct pbuf *p, const ip_
     }
     /* now we wait for the tunneler app to call ziti_tunneler_dial_complete() */
 
-    //pbuf_free(p);
-    return 0; // TODO we should return 1, but that seems to cause the client to stall irrecoverably.
+    pbuf_free(p);
+    return 1;
 }

--- a/lib/tunneler_tcp.c
+++ b/lib/tunneler_tcp.c
@@ -259,7 +259,6 @@ u8_t recv_tcp(void *tnlr_ctx_arg, struct raw_pcb *pcb, struct pbuf *p, const ip_
 
     struct tcp_pcb *npcb = new_tcp_pcb(src, dst, tcphdr);
     tunneler_io_context tnlr_io_ctx = new_tunneler_io_context(tnlr_ctx, intercept_ctx->service_name, npcb);
-    ZITI_LOG(INFO, "created tnlr_io_ctx %p", tnlr_io_ctx);
     void *ziti_io_ctx = zdial(intercept_ctx, tnlr_io_ctx);
     if (ziti_io_ctx == NULL) {
         ZITI_LOG(ERROR, "ziti_dial(%s) failed", intercept_ctx->service_name);

--- a/lib/tunneler_udp.c
+++ b/lib/tunneler_udp.c
@@ -24,7 +24,7 @@ static void to_ziti(tunneler_io_context *tnlr_io_ctx_p, void *ziti_io_ctx, struc
     }
 
     do {
-        ZITI_LOG(INFO, "writing %d bytes to ziti", recv_data->len);
+        ZITI_LOG(DEBUG, "writing %d bytes to ziti", recv_data->len);
         ziti_sdk_write_cb zwrite = tnlr_io_ctx->tnlr_ctx->opts.ziti_write;
         struct write_ctx_s *wr_ctx = calloc(1, sizeof(struct write_ctx_s));
         wr_ctx->pbuf = recv_data;
@@ -39,7 +39,18 @@ static void to_ziti(tunneler_io_context *tnlr_io_ctx_p, void *ziti_io_ctx, struc
     } while (recv_data != NULL);
 }
 
-/** called by lwip when a packet arrives from a connected client */
+/** called by lwip when a packet arrives from a connected client and the ziti service is not yet connected */
+void on_udp_client_data_enqueue(void *tnlr_io_context, struct udp_pcb *pcb, struct pbuf *p, const ip_addr_t *addr, u16_t port) {
+    tunneler_io_context tnlr_io_ctx = tnlr_io_context;
+    if (tnlr_io_ctx->udp.queued == NULL) {
+        tnlr_io_ctx->udp.queued = p;
+    } else {
+        pbuf_cat(tnlr_io_ctx->udp.queued, p);
+    }
+    ZITI_LOG(INFO, "queued %d bytes", tnlr_io_ctx->udp.queued->len);
+}
+
+/** called by lwip when a packet arrives from a connected client and the ziti service is connected */
 void on_udp_client_data(void *io_context, struct udp_pcb *pcb, struct pbuf *p, const ip_addr_t *addr, u16_t port) {
     if (io_context == NULL) {
         ZITI_LOG(INFO, "conn was closed");
@@ -48,26 +59,7 @@ void on_udp_client_data(void *io_context, struct udp_pcb *pcb, struct pbuf *p, c
     ZITI_LOG(DEBUG, "on_udp_client_data %d bytes from %s:%d", p->len, ipaddr_ntoa(addr), port);
 
     struct io_ctx_s *io_ctx = (struct io_ctx_s *) io_context;
-    tunneler_io_context tnlr_io_ctx = *io_ctx->tnlr_io_ctx_p;
-    switch (tnlr_io_ctx->udp.dial_status) {
-        case initiated:
-            ZITI_LOG(INFO, "dial_status is initiated");
-            if (tnlr_io_ctx->udp.queued == NULL) {
-                tnlr_io_ctx->udp.queued = p;
-            } else {
-                pbuf_cat(tnlr_io_ctx->udp.queued, p);
-            }
-            ZITI_LOG(INFO, "queued %d bytes", tnlr_io_ctx->udp.queued->len);
-            return;
-        case succeeded:
-            to_ziti(io_ctx->tnlr_io_ctx_p, io_ctx->ziti_io_ctx, p);
-            break;
-        case failed:
-        default:
-            ZITI_LOG(INFO, "dial_status is failed or invalid");
-            ziti_tunneler_close(io_ctx->tnlr_io_ctx_p);
-            return;
-    }
+    to_ziti(io_ctx->tnlr_io_ctx_p, io_ctx->ziti_io_ctx, p);
 }
 
 void tunneler_udp_ack(struct write_ctx_s *write_ctx) {
@@ -85,7 +77,13 @@ int tunneler_udp_close(struct udp_pcb *pcb) {
 }
 
 void tunneler_udp_dial_completed(tunneler_io_context *tnlr_io_ctx, void *ziti_io_ctx, bool ok) {
-    (*tnlr_io_ctx)->udp.dial_status = ok ? succeeded : failed;
+    struct io_ctx_s *io_ctx = calloc(1, sizeof(struct io_ctx_s));
+    io_ctx->tnlr_io_ctx_p = tnlr_io_ctx;
+    io_ctx->ziti_io_ctx = ziti_io_ctx;
+    struct udp_pcb *pcb = (*tnlr_io_ctx)->udp.pcb;
+    /* change recv callback to send packets that arrive instead of queuing */
+    udp_recv(pcb, on_udp_client_data, io_ctx);
+
     /* send any data that was queued while waiting for the dial to complete */
     if (ok) {
         to_ziti(tnlr_io_ctx, ziti_io_ctx, NULL);
@@ -156,6 +154,11 @@ u8_t recv_udp(void *tnlr_ctx_arg, struct raw_pcb *pcb, struct pbuf *p, const ip_
 
     /* make a new pcb for this connection and register it with lwip */
     struct udp_pcb *npcb = udp_new();
+    if (npcb == NULL) {
+        ZITI_LOG(ERROR, "unable to allocate UDP pcb");
+        pbuf_free(p);
+        return 1;
+    }
     ip_addr_set_ipaddr(&npcb->local_ip, &dst);
     npcb->local_port = dst_p;
     err_t err = udp_connect(npcb, &src, src_p);
@@ -173,7 +176,6 @@ u8_t recv_udp(void *tnlr_ctx_arg, struct raw_pcb *pcb, struct pbuf *p, const ip_
     ctx->proto = tun_udp;
     ctx->service_name = intercept_ctx->service_name;
     ctx->udp.pcb = npcb;
-    ctx->udp.dial_status = initiated;
     ctx->udp.queued = NULL;
 
     void *ziti_io_ctx = zdial(intercept_ctx, ctx);
@@ -185,12 +187,8 @@ u8_t recv_udp(void *tnlr_ctx_arg, struct raw_pcb *pcb, struct pbuf *p, const ip_
         return 1;
     }
 
-    struct io_ctx_s *io_ctx = calloc(1, sizeof(struct io_ctx_s));
-    io_ctx->tnlr_io_ctx_p = &ctx;
-    io_ctx->ziti_io_ctx = ziti_io_ctx;
-    udp_recv(npcb, on_udp_client_data, io_ctx);
-
-    return 0; /* lwip will call on_udp_client_data for this packet */
+    udp_recv(npcb, on_udp_client_data_enqueue, ctx);
+    return 0; /* lwip will call on_udp_client_data_enqueue for this packet */
 }
 
 ssize_t tunneler_udp_write(struct udp_pcb *pcb, const void *data, size_t len) {

--- a/lib/ziti_tunneler_cbs.c
+++ b/lib/ziti_tunneler_cbs.c
@@ -12,11 +12,12 @@ void on_ziti_connect(ziti_connection conn, int status) {
     }
 }
 
+/** called by ziti SDK when ziti service has data for the client */
 ssize_t on_ziti_data(ziti_connection conn, uint8_t *data, ssize_t len) {
     ziti_io_context *ziti_io_ctx = ziti_conn_data(conn);
     ZITI_LOG(TRACE, "got %zd bytes from ziti", len);
     if (ziti_io_ctx == NULL || ziti_io_ctx->tnlr_io_ctx == NULL) {
-        ZITI_LOG(ERROR, "bad ziti_io_context");
+        ZITI_LOG(DEBUG, "null io_context - connection may have been closed already");
         return len;
     }
     if (len > 0) {

--- a/lib/ziti_tunneler_priv.h
+++ b/lib/ziti_tunneler_priv.h
@@ -27,9 +27,6 @@ struct tunneler_io_ctx_s {
         struct {
             struct udp_pcb *pcb;
             struct pbuf *queued;
-            enum ziti_dial_status { initiated, succeeded, failed } dial_status;
-            //ziti_udp_cb cb;
-            //void *ctx;
         } udp;
     };
 };


### PR DESCRIPTION
Don't dereference the tunneler io context.

As this PR (draft) stands now it is working well for tcp intercept. I'll update udp with another commit but wanted to make this much available if it's useful.