### PR TITLE
Lwip stability

### DIFF
--- a/lib/intercept.c
+++ b/lib/intercept.c
@@ -41,6 +41,7 @@ extern int add_v1_intercept(tunneler_context tnlr_ctx, const void *ziti_ctx, con
         last->next = new;
     }
 
+    ZITI_LOG(INFO, "intercepting %s:%d for service %s (id %s)", hostname, port, service_name, service_id);
     return 0;
 }
 
@@ -54,7 +55,8 @@ void remove_intercept(tunneler_context tnlr_ctx, const char *service_id) {
 
     for (intercept = tnlr_ctx->intercepts; intercept != NULL; intercept = intercept->next) {
         if (strcmp(intercept->ctx.service_id, service_id) == 0) {
-            ZITI_LOG(INFO, "removing intercept for service %s (id %s)", intercept->ctx.service_name, service_id);
+            ZITI_LOG(INFO, "removing intercept %s:%d for service %s (id %s)",
+                    intercept->cfg.v1.hostname, intercept->cfg.v1.port, intercept->ctx.service_name, service_id);
             if (prev != NULL) {
                 prev->next = intercept->next;
             } else {

--- a/lib/lwip/lwipopts.h
+++ b/lib/lwip/lwipopts.h
@@ -5,23 +5,28 @@
 
 #define MEM_SIZE              524288      /* the size of the heap memory (1600) */
 
+#if SCAREY_DEBUGGING_LWIP
+#define MEMP_OVERFLOW_CHECK   2           /* reserves bytes before and after each memp element in every pool and fills it with a prominent default value */
+#define MEMP_SANITY_CHECK     1           /* run a sanity check after each mem_free() to make sure that the linked list of heap elements is not corrupted */
+//#define LWIP_ALLOW_MEM_FREE_FROM_OTHER_CONTEXT 0
+#endif
 //#define MEMP_NUM_PBUF       64          /* number of memp struct pbufs (used for PBUF_ROM and PBUF_REF) */
 
 #define MEMP_NUM_TCP_PCB      64          /* simultaneously active TCP connections (5) */
-#define MEMP_NUM_TCP_SEG      1024          /* simultaneously queued TCP segments (16) */
+#define MEMP_NUM_TCP_SEG      1024        /* simultaneously queued TCP segments (16) */
 
 #define PBUF_POOL_SIZE        512         /* number of buffers in the pbuf pool (16) */
 
-#define TCP_WND               0xffff     /* size of a TCP window. when using TCP_RCV_SCALE, TCP_WND is the total size with scaling applied (4 * TCP_MSS) */
-#define TCP_MSS               16384      /* TCP Maximum segment size (536) */
+#define TCP_WND               0xffff      /* size of a TCP window. when using TCP_RCV_SCALE, TCP_WND is the total size with scaling applied (4 * TCP_MSS) */
+#define TCP_MSS               16384       /* TCP Maximum segment size (536) */
 #define TCP_SND_BUF           TCP_WND     /* TCP sender buffer space in bytes (2 * TCP_MSS) */
 #define TCP_SND_QUEUELEN      64          /* TCP sender buffer space in pbufs ((4 * (TCP_SND_BUF) + (TCP_MSS - 1))/(TCP_MSS)) */
 // TCP_SNDQUEUELEN_OVERFLOW = 0xffffu - 3
 #define TCP_SNDLOWAT          (0xffff-(4*TCP_MSS)-1) /* TCP writable space (bytes). must be less than TCP_SND_BUF. the amount of space which must be available in the TCP snd_buf for select to return writable (combined with TCP_SNDQUEUELOWAT) LWIP_MIN(LWIP_MAX(((TCP_SND_BUF)/2), (2 * TCP_MSS) + 1), (TCP_SND_BUF) - 1) */
 #define LWIP_WND_SCALE        1           /* set to 1 to enable window scaling */
-#define TCP_RCV_SCALE         7          /* desired scaling factor - shift count in the range of [0..14] */
+#define TCP_RCV_SCALE         7           /* desired scaling factor - shift count in the range of [0..14] */
 
-#define LWIP_SINGLE_NETIF 1
+#define LWIP_SINGLE_NETIF 1               /* avoid some lwip "routing" logic */
 
 // APIs
 #define LWIP_RAW 1
@@ -29,8 +34,8 @@
 #define LWIP_SOCKET 0
 
 // protocols
-#define LWIP_IPV6 1                      /* enable ipv6 */
-#define IPV6_FRAG_COPYHEADER 1           /* avoid assert in lwip code when ipv6 is enabled */
+#define LWIP_IPV6 1                       /* enable ipv6 */
+#define IPV6_FRAG_COPYHEADER 1            /* avoid assert in lwip code when ipv6 is enabled */
 
 #ifdef _WIN32
 #define LWIP_NORAND 1

--- a/lib/ziti_tunneler.c
+++ b/lib/ziti_tunneler.c
@@ -75,7 +75,8 @@ void free_tunneler_io_context(tunneler_io_context *tnlr_io_ctx) {
  * - let the client know that we have a connection (e.g. send SYN/ACK)
  */
 void ziti_tunneler_dial_completed(tunneler_io_context *tnlr_io_ctx, void *ziti_io_ctx, bool ok) {
-    ZITI_LOG(INFO, "ziti dial completed: svc=%s, ok=%d", (*tnlr_io_ctx)->service_name, ok);
+    const char *status = ok ? "succeeded" : "failed";
+    ZITI_LOG(INFO, "ziti dial %s: svc=%s, client=%s", status, (*tnlr_io_ctx)->service_name, (*tnlr_io_ctx)->client);
 
     switch ((*tnlr_io_ctx)->proto) {
         case tun_tcp:
@@ -143,7 +144,8 @@ int ziti_tunneler_close(tunneler_io_context *tnlr_io_ctx) {
         ZITI_LOG(INFO, "null tnlr_io_ctx");
         return 0;
     }
-
+    ZITI_LOG(INFO, "closing connection: service=%s, client=%s",
+            (*tnlr_io_ctx)->service_name, (*tnlr_io_ctx)->client);
     switch ((*tnlr_io_ctx)->proto) {
         case tun_tcp:
             tunneler_tcp_close((*tnlr_io_ctx)->tcp);

--- a/lib/ziti_tunneler.c
+++ b/lib/ziti_tunneler.c
@@ -76,7 +76,7 @@ void free_tunneler_io_context(tunneler_io_context *tnlr_io_ctx) {
  */
 void ziti_tunneler_dial_completed(tunneler_io_context *tnlr_io_ctx, void *ziti_io_ctx, bool ok) {
     const char *status = ok ? "succeeded" : "failed";
-    ZITI_LOG(INFO, "ziti dial %s: svc=%s, client=%s", status, (*tnlr_io_ctx)->service_name, (*tnlr_io_ctx)->client);
+    ZITI_LOG(INFO, "ziti dial %s: service=%s, client=%s", status, (*tnlr_io_ctx)->service_name, (*tnlr_io_ctx)->client);
 
     switch ((*tnlr_io_ctx)->proto) {
         case tun_tcp:

--- a/lib/ziti_tunneler_cbs.c
+++ b/lib/ziti_tunneler_cbs.c
@@ -27,6 +27,7 @@ ssize_t on_ziti_data(ziti_connection conn, uint8_t *data, ssize_t len) {
         }
         return accepted;
     } else {
+        ZITI_LOG(INFO, "ziti service closed connection");
         ziti_tunneler_close(&ziti_io_ctx->tnlr_io_ctx);
     }
     return len;

--- a/lib/ziti_tunneler_priv.h
+++ b/lib/ziti_tunneler_priv.h
@@ -21,6 +21,7 @@ typedef enum  {
 struct tunneler_io_ctx_s {
     tunneler_context    tnlr_ctx;
     const char *        service_name;
+    char                client[32];
     tunneler_proto_type proto;
     union {
         struct tcp_pcb *tcp;

--- a/programs/ziti-tunneler/netif_driver/darwin/utun.c
+++ b/programs/ziti-tunneler/netif_driver/darwin/utun.c
@@ -69,46 +69,8 @@ ssize_t utun_write(netif_handle tun, const void *buf, size_t len) {
     return utun_data_len(writev(tun->fd, iv, 2));
 }
 
-struct check_data_s {
-    netif_handle dev;
-    void *       netif;
-    packet_cb    cb;
-};
-
-static void on_uv_check_poll(uv_check_t *handle) {
-    struct check_data_s *chk_data = handle->data;
-    struct pollfd fd = {
-            .fd = chk_data->dev->fd,
-            .events = POLLIN,
-            .revents = 0,
-    };
-    do {
-        int n = poll(&fd, 1, 0);
-        if (n == -1) {
-            perror("poll failed");
-            exit(1);
-        }
-
-        if (fd.revents & POLLIN) {
-            char buf[0xffff];
-
-            ssize_t nr = utun_read(chk_data->dev, buf, sizeof(buf));
-            chk_data->cb(buf, nr, chk_data->netif);
-        }
-    } while (fd.revents & POLLIN);
-}
-
-int utun_setup(netif_handle dev, uv_loop_t *loop, packet_cb cb, void* netif) {
-    uv_check_t *chk = malloc(sizeof(uv_check_t));
-
-    struct check_data_s *chk_data = calloc(1, sizeof(struct check_data_s)); // TODO free this
-    chk_data->dev = dev;
-    chk_data->netif = netif;
-    chk_data->cb = cb;
-    uv_check_init(loop, chk);
-    chk->data = chk_data;
-    uv_check_start(chk, on_uv_check_poll);
-    return 0;
+int utun_uv_poll_init(netif_handle tun, uv_loop_t *loop, uv_poll_t *tun_poll_req) {
+    return uv_poll_init(loop, tun_poll_req, tun->fd);
 }
 
 /**
@@ -195,7 +157,7 @@ netif_driver utun_open(char *error, size_t error_len) {
     driver->handle       = tun;
     driver->read         = utun_read;
     driver->write        = utun_write;
-    driver->setup        = utun_setup;
+    driver->uv_poll_init = utun_uv_poll_init;
     driver->close        = utun_close;
 
     return driver;


### PR DESCRIPTION
This PR mainly fixes an issue that caused the tunneler SDK to incorrectly intercept retried SYN segments instead of letting lwip handle them (commit 1c252ad). With this change the Darwin and linux tunnelers have been running iperf loops for hours.

Along the way I also added some logging improvements that are worthwhile. 

Finally, this PR includes a change to the Darwin tun polling that reduces latency by letting uv poll the tun directly (via uv_poll) instead of calling `poll()` from a uv_check callback (commit 1214626).